### PR TITLE
Basic Errorbar function

### DIFF
--- a/mpl_uncertainties/plots.py
+++ b/mpl_uncertainties/plots.py
@@ -8,14 +8,29 @@ __all__ = [
     "errorbar",
 ]
 import matplotlib.pyplot as plt
+import numpy as np
+from uncertainties import unumpy as unp, UFloat
 
+def errorbar(x, y, ax=None, **kwargs):
+    """
+    Plots errorbar from x,y
+    """
+    if not isinstance(x, np.ndarray) or not np.all([isinstance(x_i, UFloat) for x_i in x]):
+        raise TypeError("x must be numpy arrays (np.ndarray) of uncertainties floats (UFloat)")
+    if not isinstance(y, np.ndarray) or not np.all([isinstance(y_i, UFloat) for y_i in y]):
+        raise TypeError("y must be numpy arrays (np.ndarray) of uncertainties floats (UFloat)")
 
-def errorbar(ux, uy, *args, **kwargs):
-    return plt.errorbar(
-        [a.n for a in ux],
-        [a.n for a in uy],
-        [a.s for a in ux],
-        [a.s for a in uy],
-        *args,
-        **kwargs,
-    )
+    # Pull out the current axes if not passed (only after this function began running)
+    if ax is None:
+        ax = plt.gca()
+        
+    # Choose default color if not passed
+    if 'color' not in kwargs:
+        kwargs.setdefault('color', ax._get_lines._cycler_items[ax._get_lines._idx]["color"])
+        ax._get_lines._idx = (ax._get_lines._idx + 1) % len(ax._get_lines._cycler_items)
+
+    # Plot the errorbar
+    kwargs.setdefault('marker', '.')
+    kwargs.setdefault('linestyle', '')
+    kwargs.setdefault('capsize', 2)
+    ax.errorbar(unp.nominal_values(x), unp.nominal_values(y), xerr=unp.std_devs(x), yerr=unp.std_devs(y), **kwargs)


### PR DESCRIPTION
Hi @andrewgsavage 

I made basic errorbar function (after this PR I will also make fit plotting function).
But im not sure if I like the usage of the library, seems to me that for now the library is used as such:
```python
import matplotlib.pyplot as plt
from mpl-uncertainties import errorbar

...
data_plot = errorbar(x, y)
plt.add_patch(data_plot)
```
But I prefer it to be like this:
```python
import matplotlib.pyplot as plt
import mpl-uncertainties as uplt;

...
uplt.plot(x, y)
```
(but without actually installing mathplotlib as a depencency, just raise an error if the user didnt do `import mathplotlib`)

Do you agree?